### PR TITLE
fetcher関数の実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@clerk/nextjs": "^6.36.2",
     "next": "16.0.10",
     "react": "19.2.1",
-    "react-dom": "19.2.1"
+    "react-dom": "19.2.1",
+    "zod": "^4.2.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: 19.2.1
         version: 19.2.1(react@19.2.1)
+      zod:
+        specifier: ^4.2.1
+        version: 4.2.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.6.1
@@ -2523,8 +2526,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+  zod@4.2.1:
+    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
 
 snapshots:
 
@@ -3946,8 +3949,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 9.39.1(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.1.13
-      zod-validation-error: 4.0.2(zod@4.1.13)
+      zod: 4.2.1
+      zod-validation-error: 4.0.2(zod@4.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5274,8 +5277,8 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  zod-validation-error@4.0.2(zod@4.1.13):
+  zod-validation-error@4.0.2(zod@4.2.1):
     dependencies:
-      zod: 4.1.13
+      zod: 4.2.1
 
-  zod@4.1.13: {}
+  zod@4.2.1: {}

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 type FetchProps<T> = {
-  schemas: z.ZodType<T>;
+  schema: z.ZodType<T>;
   url: string;
   options?: RequestInit;
 };
@@ -9,13 +9,13 @@ type FetchProps<T> = {
 /**
  * 共通のフェッチ関数
  * @param {object} props - 引数オブジェクト
- * @param {z.ZodType<T>} props.schemas - Zodスキーマ
+ * @param {z.ZodType<T>} props.schema - Zodスキーマ
  * @param {string} props.url - APIエンドポイントのURL
  * @param {RequestInit} [props.options] - フェッチオプション
  * @returns {Promise<T>} - パースされたデータ
  * @throws {Error} - フェッチエラーまたはパースエラー
  */
-export const customFetch = async <T>({ schemas, url, options = {} }: FetchProps<T>): Promise<T> => {
+export const customFetch = async <T>({ schema, url, options = {} }: FetchProps<T>): Promise<T> => {
   try {
     const response = await fetch(url, {
       ...options,
@@ -31,8 +31,12 @@ export const customFetch = async <T>({ schemas, url, options = {} }: FetchProps<
 
     const result = await response.json();
 
-    return schemas.parse(result.data);
+    return schema.parse(result);
   } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Fetch error:", error);
+    }
+
     throw error;
   }
 };
@@ -40,15 +44,15 @@ export const customFetch = async <T>({ schemas, url, options = {} }: FetchProps<
 /**
  * バックエンドと直接通信を行うフェッチ関数（Route Handlerでは動かない）
  * @param {object} props - 引数オブジェクト
- * @param {z.ZodType<T>} props.schemas - Zodスキーマ
+ * @param {z.ZodType<T>} props.schema - Zodスキーマ
  * @param {string} props.url - APIエンドポイントのURL
  * @param {RequestInit} [props.options] - フェッチオプション
  * @returns {Promise<T>} - パースされたデータ
  * @throws {Error} - フェッチエラーまたはパースエラー
  */
-export async function backendFetch<T>({ schemas, url, options }: FetchProps<T>): Promise<T> {
-  return await customFetch({
-    schemas,
+export async function backendFetch<T>({ schema, url, options = {} }: FetchProps<T>): Promise<T> {
+  return customFetch({
+    schema,
     url,
     options: { ...options, credentials: "include" },
   });
@@ -57,15 +61,15 @@ export async function backendFetch<T>({ schemas, url, options }: FetchProps<T>):
 /**
  * Route Handlerと直接通信を行うフェッチ関数
  * @param {object} props - 引数オブジェクト
- * @param {z.ZodType<T>} props.schemas - Zodスキーマ
+ * @param {z.ZodType<T>} props.schema - Zodスキーマ
  * @param {string} props.url - APIエンドポイントのURL
  * @param {RequestInit} [props.options] - フェッチオプション
  * @returns {Promise<T>} - パースされたデータ
  * @throws {Error} - フェッチエラーまたはパースエラー
  */
-export async function routeFetch<T>({ schemas, url, options }: FetchProps<T>): Promise<T> {
-  return await customFetch({
-    schemas,
+export async function apiFetch<T>({ schema, url, options = {} }: FetchProps<T>): Promise<T> {
+  return customFetch({
+    schema,
     url,
     options: { ...options, credentials: "same-origin" },
   });

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+type FetchProps<T> = {
+  schemas: z.ZodType<T>;
+  url: string;
+  options?: RequestInit;
+};
+
+/**
+ * 共通のフェッチ関数
+ * @param {object} props - 引数オブジェクト
+ * @param {z.ZodType<T>} props.schemas - Zodスキーマ
+ * @param {string} props.url - APIエンドポイントのURL
+ * @param {RequestInit} [props.options] - フェッチオプション
+ * @returns {Promise<T>} - パースされたデータ
+ * @throws {Error} - フェッチエラーまたはパースエラー
+ */
+export const customFetch = async <T>({ schemas, url, options = {} }: FetchProps<T>): Promise<T> => {
+  try {
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Status code: ${response.status}`);
+    }
+
+    const result = await response.json();
+
+    return schemas.parse(result.data);
+  } catch (error) {
+    throw error;
+  }
+};
+
+/**
+ * バックエンドと直接通信を行うフェッチ関数（Route Handlerでは動かない）
+ * @param {object} props - 引数オブジェクト
+ * @param {z.ZodType<T>} props.schemas - Zodスキーマ
+ * @param {string} props.url - APIエンドポイントのURL
+ * @param {RequestInit} [props.options] - フェッチオプション
+ * @returns {Promise<T>} - パースされたデータ
+ * @throws {Error} - フェッチエラーまたはパースエラー
+ */
+export async function backendFetch<T>({ schemas, url, options }: FetchProps<T>): Promise<T> {
+  return await customFetch({
+    schemas,
+    url,
+    options: { ...options, credentials: "include" },
+  });
+}
+
+/**
+ * Route Handlerと直接通信を行うフェッチ関数
+ * @param {object} props - 引数オブジェクト
+ * @param {z.ZodType<T>} props.schemas - Zodスキーマ
+ * @param {string} props.url - APIエンドポイントのURL
+ * @param {RequestInit} [props.options] - フェッチオプション
+ * @returns {Promise<T>} - パースされたデータ
+ * @throws {Error} - フェッチエラーまたはパースエラー
+ */
+export async function routeFetch<T>({ schemas, url, options }: FetchProps<T>): Promise<T> {
+  return await customFetch({
+    schemas,
+    url,
+    options: { ...options, credentials: "same-origin" },
+  });
+}

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -61,7 +61,7 @@ export async function backendFetch<T>({ schema, url, options = {} }: FetchProps<
   return customFetch({
     schema,
     url,
-    options: { ...options, headers: { Authorization: `Bearer ${token}`, ...options.headers } },
+    options: { ...options, headers: { ...options.headers, Authorization: `Bearer ${token}` } },
   });
 }
 


### PR DESCRIPTION
# Pull Request

## 関連Issue

- Close #13

## 概要

フロントエンドで API 通信を行う際に使用するカスタム fetcher 関数を `lib/fetch.ts` に実装しました。型安全性と再利用性を確保し、DRY 原則に従ったコードの提供を実現しています。

## 変更内容

- `lib/fetch.ts` に以下の関数を実装：
  - `customFetch<T>()` - 基本的なフェッチ関数（型安全）
  - `routeHandlerFetch<T>()` - API Route Handler 向けフェッチ関数
  - `backendFetch<T>()` - バックエンド直接通信向けフェッチ関数（認証付き）
- Zod スキーマを使用した型検証

## 変更箇所

- [x] Frontend
  - [x] src/lib/fetch.ts
  - [x] package.json
  - [x] pnpm-lock.yaml

## チェック項目

- [x] Lint
- [x] Format

## 注意事項

- Zod による実行時型検証で API レスポンスの安全性を確保
- エラーハンドリングの統一により、エラー処理を一元化